### PR TITLE
Reflect the markdown format in the go documentation

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -9,9 +9,9 @@ movements. Katas are simple, practical and well written Go programs.
     code -a katas.md     # write down katas you've done
 
 katas.md format:
-* yyyy-mm-dd: areader
+\* yyyy-mm-dd: areader
 
 katas.md format for multiple katas completed in one day:
-* yyyy-mm-dd: clock2, areader, netcat1
+\* yyyy-mm-dd: clock2, areader, netcat1
 */
 package gokatas

--- a/doc.go
+++ b/doc.go
@@ -7,5 +7,11 @@ movements. Katas are simple, practical and well written Go programs.
     code areader         # let's practice: delete and try to write it back
     go run areader/cmd/* # check it's working; or `git diff`
     code -a katas.md     # write down katas you've done
+
+katas.md format:
+* yyyy-mm-dd: areader
+
+katas.md format for multiple katas completed in one day:
+* yyyy-mm-dd: clock2, areader, netcat1
 */
 package gokatas


### PR DESCRIPTION
The go documentation should demonstrate to the user how to format the completed katas in the doc.go, so that this is not a mystery to users who may have ran `code -a katas.md` before figuring this out